### PR TITLE
[src] Add option to reload a SOFA scene which is already registered in the SofaContext. Will clear on the SOFA side, reload and then reconnect objects on the Unity side

### DIFF
--- a/Core/Scripts/Core/DAGNode/SofaDAGNode.cs
+++ b/Core/Scripts/Core/DAGNode/SofaDAGNode.cs
@@ -320,7 +320,8 @@ namespace SofaUnity
         {
             if (m_impl != null)
             {
-                SofaLog("SofaDAGNode " + UniqueNameId + " already has a SofaDAGNodeAPI.", 2);
+                // This is not an error if unity node is not deleted. The api is still there and jsut need to be reconnected.
+                SofaLog("SofaDAGNode " + UniqueNameId + " already has a SofaDAGNodeAPI.", 0);
                 return;
             }
             

--- a/Core/Scripts/Core/Data/SofaDataArchiver.cs
+++ b/Core/Scripts/Core/Data/SofaDataArchiver.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using SofaUnity;
-using XCharts.Runtime;
 
 namespace SofaUnity
 {

--- a/Core/Scripts/Editor/SofaContextEditor.cs
+++ b/Core/Scripts/Editor/SofaContextEditor.cs
@@ -184,10 +184,12 @@ namespace SofaUnity
                 EditorGUILayout.Separator();
             }
 
+            EditorGUILayout.Separator();
             // Label of the filename loaded
             EditorGUILayout.LabelField("Scene Filename: ", context.SceneFileMgr.SceneFilename);
 
             context.UnLoadScene = GUILayout.Button("Unload Scene file");
+            context.ReloadScene = GUILayout.Button("Reload Sofa Scene file");
             EditorGUILayout.Separator();
         }
 

--- a/Core/Scripts/SofaContext.cs
+++ b/Core/Scripts/SofaContext.cs
@@ -150,19 +150,35 @@ namespace SofaUnity
             }
         }
 
-
+        /// Setter to unload the current scene and clear the sofa context. Will call @sa ClearSofaScene.
         public bool UnLoadScene
         {
             set
             {
                 if (value && m_impl != null)
                 {
-                    Debug.Log("UnLoadScene " + value);
+                    if (m_log)
+                        Debug.Log("#### SofaContext UnLoadScene: " + value);
+
                     ClearSofaScene();
                 }
             }
         }
 
+        /// Setter to reload the current scene. Will clear SOFA scene and reload it internally. Then will reconnect the graph in Unity. Will call @sa ReloadSofaScene.
+        public bool ReloadScene
+        {
+            set
+            {
+                if (value && m_impl != null)
+                {
+                    if (m_log)
+                        Debug.Log("#### SofaContext ReloadScene: " + value);
+
+                    ReloadSofaScene();
+                }
+            }
+        }
         
         ////////////////////////////////////////////
         ////////      scale conversions      ///////
@@ -619,6 +635,8 @@ namespace SofaUnity
             DoCatchSofaMessages();
         }
 
+
+        /// Method to reconnect the current scene already loaded in SOFA with the existing Unity GameObject Hierarchy.
         protected void ReconnectSofaScene()
         {
             if (m_sceneFileMgr == null)
@@ -647,6 +665,20 @@ namespace SofaUnity
             DoCatchSofaMessages();
         }
 
+
+        /// Method to reload the current scene. Will clear SOFA scene and reload it internally. Then will reconnect the graph in Unity.
+        public void ReloadSofaScene()
+        {
+            m_impl.stop();
+            m_impl.unload();
+
+            ReconnectSofaScene();
+
+            m_impl.start();
+        }
+
+
+        /// Method to clear the current scene in SOFA and clear the graph in Unity.
         public void ClearSofaScene()
         {
             m_impl.stop();


### PR DESCRIPTION
https://github.com/user-attachments/assets/1409ab2a-dc6f-46c0-aa84-b0e20a4ef0aa

You can't see in the video but I'm editing the XML scene file to add the stick collision model

--- 
fix #233
SOFAU3D-3 #done #time 1h
