### PR TITLE
[src] Fix problem of wrong dt and gravity values applied when reconnecting scenes

### DIFF
--- a/Core/Scripts/SofaContext.cs
+++ b/Core/Scripts/SofaContext.cs
@@ -662,7 +662,9 @@ namespace SofaUnity
                 m_impl.loadScene(m_sceneFileMgr.AbsoluteFilename());
             }
 
-            // Do not retrieve timestep of gravity in case it has been changed in editor
+            // This is cause of error. TODO: find a way to not retrieve those values only if they have been changed intentionnaly in the editor
+            m_timeStep = m_impl.timeStep;
+            m_gravity = m_impl.getGravity();
 
             // re-create objects after scene loading and before graph reconnection
             foreach (SofaBaseObject obj in m_objects)


### PR DESCRIPTION
Need to find a better way to detect if values have been changed on purpose in the editor.

Should solve a lot of strange behaviors between first load and reloading scenes. 

fix https://github.com/InfinyTech3D/SurgiViz4D/issues/318