### PR TITLE
[Python] Fix Problem for python scenes use in builds

### DIFF
--- a/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
+using System.IO;
 
 namespace SofaUnityAPI
 {
@@ -80,7 +81,9 @@ namespace SofaUnityAPI
             }
 
             CopyAssetToPersistent();
-
+#if !UNITY_EDITOR
+            RegenerateSofaIni();
+#endif
             // load the sofaIni file
             string pathIni = Application.dataPath + "/SofaUnity/Core/Plugins/Native/x64/sofa.ini";
             string sharePath = sofaPhysicsAPI_loadSofaIni(m_native, pathIni);
@@ -108,6 +111,30 @@ namespace SofaUnityAPI
             }
 
             m_sofaVersion = sofaPhysicsAPI_version(m_native);
+        }
+
+
+        /// <summary>
+        /// simple method to regenerate sofa.ini
+        /// PS: don't update the liscence path it's not needed and will make the app crash
+        /// </summary>
+        private static void RegenerateSofaIni()
+        {
+            string dataPath = Application.dataPath.Replace("\\", "/");
+            string pluginsPath = dataPath + "/Plugins/x86_64";
+            string scenesPath = dataPath + "/SofaUnity/scenes/SofaScenes";
+            //string licensePath = dataPath + "/License/";
+            string iniPath = dataPath + "/SofaUnity/Core/Plugins/Native/x64/sofa.ini";
+
+            using (StreamWriter iniFile = new StreamWriter(iniPath))
+            {
+                iniFile.WriteLine("SHARE_DIR=" + scenesPath);
+                iniFile.WriteLine("EXAMPLES_DIR=" + scenesPath);
+                //iniFile.WriteLine("LICENSE_DIR=" + licensePath);
+                iniFile.WriteLine("BUILD_DIR=" + pluginsPath);
+            }
+
+            Debug.Log("[SofaUnity] sofa.ini regenerated at: " + iniPath);
         }
 
         /// Destructor

--- a/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
+++ b/Core/Plugins/SofaUnityAPI/SofaContextAPI.cs
@@ -116,21 +116,20 @@ namespace SofaUnityAPI
 
         /// <summary>
         /// simple method to regenerate sofa.ini
-        /// PS: don't update the liscence path it's not needed and will make the app crash
         /// </summary>
         private static void RegenerateSofaIni()
         {
             string dataPath = Application.dataPath.Replace("\\", "/");
             string pluginsPath = dataPath + "/Plugins/x86_64";
             string scenesPath = dataPath + "/SofaUnity/scenes/SofaScenes";
-            //string licensePath = dataPath + "/License/";
+            string licensePath = dataPath + "/License/";
             string iniPath = dataPath + "/SofaUnity/Core/Plugins/Native/x64/sofa.ini";
 
             using (StreamWriter iniFile = new StreamWriter(iniPath))
             {
                 iniFile.WriteLine("SHARE_DIR=" + scenesPath);
                 iniFile.WriteLine("EXAMPLES_DIR=" + scenesPath);
-                //iniFile.WriteLine("LICENSE_DIR=" + licensePath);
+                iniFile.WriteLine("LICENSE_DIR=" + licensePath);
                 iniFile.WriteLine("BUILD_DIR=" + pluginsPath);
             }
 

--- a/Core/Scripts/Core/System/PluginManager.cs
+++ b/Core/Scripts/Core/System/PluginManager.cs
@@ -127,6 +127,7 @@ namespace SofaUnity
                 m_availablePlugins.Add(new PluginInfo(pluginName, exist));
             }
         }
+
     }
 
 
@@ -302,6 +303,13 @@ namespace SofaUnity
             return null;
         }
 
+        public void printAvailablePlugin()
+        {
+            foreach (PluginInfo pi in m_savedPlugins)
+            {
+                Debug.Log("Loaded plugin " + pi.Name);
+            }
+        }
 
         ////////////////////////////////////////////
         //////    PluginManager private API    /////

--- a/Core/Scripts/Editor/Config/CopyConfigPostProcessor.cs
+++ b/Core/Scripts/Editor/Config/CopyConfigPostProcessor.cs
@@ -164,6 +164,7 @@ namespace SofaUnity
                 outputIniFile.WriteLine("SHARE_DIR=" + dataBuildPath);
                 outputIniFile.WriteLine("EXAMPLES_DIR=" + dataBuildPath);
                 outputIniFile.WriteLine("LICENSE_DIR=" + rootBuildPath + "/License/");
+                outputIniFile.WriteLine("BUILD_DIR=" + rootBuildPath + "/Plugins/x86_64/");
                 Debug.Log("[SofaUnity - BuildForWindows] Generate: " + outputIniPath + " file.");
             }
 
@@ -184,6 +185,20 @@ namespace SofaUnity
             if (!copyDone)
             {
                 Debug.LogError("No 'SofaScenes' folder found to copy Sofa scene related to: " + unityScenePath);
+            }
+
+            // Copy python3 folder if exists for python scene build 
+            string sourcePython3Path = Application.dataPath + "/SofaUnity/Core/Plugins/Native/x64/python3/";
+            string destPython3Path = rootBuildPath + "/Plugins/x86_64/python3/";
+
+            if (Directory.Exists(sourcePython3Path))
+            {
+                DirectoryCopy(sourcePython3Path, destPython3Path, true);
+                Debug.Log("[SofaUnity - BuildForWindows] Copied python3 folder to: " + destPython3Path);
+            }
+            else
+            {
+                Debug.LogWarning("[SofaUnity - BuildForWindows] python3 folder not found at: " + sourcePython3Path + " — skipping python3 copy.");
             }
         }
 

--- a/Core/Scripts/SofaContext.cs
+++ b/Core/Scripts/SofaContext.cs
@@ -433,11 +433,7 @@ namespace SofaUnity
 #endif
             if (m_log)
             {
-                List<PluginInfo> pluginsPresent = m_pluginMgr.GetPluginList();
-                foreach (PluginInfo pi in pluginsPresent)
-                {
-                    Debug.Log("Loaded plugin " + pi.Name);
-                }
+                m_pluginMgrm_pluginMgr.printAvailablePlugin();
             }
                 
             // start sofa instance

--- a/Core/Scripts/SofaContext.cs
+++ b/Core/Scripts/SofaContext.cs
@@ -431,6 +431,15 @@ namespace SofaUnity
 #if !UNITY_ANDROID
             m_pluginMgr.LoadPlugins();
 #endif
+            if (m_log)
+            {
+                List<PluginInfo> pluginsPresent = m_pluginMgr.GetPluginList();
+                foreach (PluginInfo pi in pluginsPresent)
+                {
+                    Debug.Log("Loaded plugin " + pi.Name);
+                }
+            }
+                
             // start sofa instance
             if (m_log)
                 Debug.Log("## SofaContext status before start: " + m_impl.contextStatus());

--- a/Core/Scripts/SofaContext.cs
+++ b/Core/Scripts/SofaContext.cs
@@ -433,7 +433,7 @@ namespace SofaUnity
 #endif
             if (m_log)
             {
-                m_pluginMgrm_pluginMgr.printAvailablePlugin();
+                m_pluginMgr.printAvailablePlugin();
             }
                 
             // start sofa instance


### PR DESCRIPTION
### Fix Problem for python scenes use in builds

When building there is now a copy of the "python" folder in x64  that is made in the build. Also fix sofa.ini problem

closes https://github.com/InfinyTech3D/SofaUnity/issues/252