### PR TITLE
[Ultrasound] Fix of AbtractSofaGraphicCall that had an error path of execution

### DIFF
--- a/Core/Plugins/SofaUnityAPI/GraphicAPI/AbstractSofaGraphicCall.cs
+++ b/Core/Plugins/SofaUnityAPI/GraphicAPI/AbstractSofaGraphicCall.cs
@@ -11,7 +11,7 @@ namespace SofaUnityAPI
         private bool m_bNewStep = false;
         private bool m_GLRenderEnd = true;
         private List<int> m_registeredRenderIDList = new List<int>();
-        public SofaUnity.SofaContext m_sofaContext = null;
+        [HideInInspector] public SofaUnity.SofaContext m_sofaContext = null;
 
         protected abstract int InitCall();
         protected abstract void BeforeDestroy();
@@ -53,6 +53,7 @@ namespace SofaUnityAPI
 
                 if (m_sofaContext)
                 {
+                    Debug.Log("just before initcall ?????");
                     int res = InitCall();
                     if (res >= 0)
                         RegisterID(res);

--- a/Core/Plugins/SofaUnityAPI/GraphicAPI/AbstractSofaGraphicCall.cs
+++ b/Core/Plugins/SofaUnityAPI/GraphicAPI/AbstractSofaGraphicCall.cs
@@ -53,7 +53,6 @@ namespace SofaUnityAPI
 
                 if (m_sofaContext)
                 {
-                    Debug.Log("just before initcall ?????");
                     int res = InitCall();
                     if (res >= 0)
                         RegisterID(res);


### PR DESCRIPTION


## **Hidden `SofaContext` from Inspector**

Previously, `SofaContext` was a public variable, but if you assigned it manually in the Inspector instead of letting the script find it automatically, it would **skip the InitCall** (critical initialization step). This was causing ultrasound rendering to fail on some scenes.

Solution : Hidden the variable in the Editor using `[HideInInspector] to maintains all existing behaviors
